### PR TITLE
fix: add alert if rows of datagrid is editing and user press save - ETI-60

### DIFF
--- a/src/components/ETIAlojamiento.jsx
+++ b/src/components/ETIAlojamiento.jsx
@@ -7,7 +7,7 @@ import { DataGrid } from '@mui/x-data-grid';
 import { createOrUpdateDoc } from 'helpers/firestore'; 
 import ETIModalMaps from './ETIModalMaps';
 
-const ETIAlojamiento = ( { idEvent, event, updateAlojamientoData }) => {
+const ETIAlojamiento = ( { idEvent, event, updateAlojamientoData, isEditingRows }) => {
 
   const [rows, setRows] = useState([]);
   const [editRowsModel, setEditRowsModel] = useState({});
@@ -108,6 +108,7 @@ const ETIAlojamiento = ( { idEvent, event, updateAlojamientoData }) => {
 
   const handleEditClick = () => {
     setIsEditing(true);
+    isEditingRows(isEditing)
     handleMenuClose();
   };
 
@@ -130,6 +131,7 @@ const ETIAlojamiento = ( { idEvent, event, updateAlojamientoData }) => {
     }
 
     setIsEditing(false);
+    isEditingRows(isEditing)
   };
 
   const columns = [

--- a/src/components/ETIDataBanks.jsx
+++ b/src/components/ETIDataBanks.jsx
@@ -6,7 +6,7 @@ import { Box, Button, Grid, Typography, Menu, MenuItem, } from '@mui/material';
 import { DataGrid } from '@mui/x-data-grid';
 import { createOrUpdateDoc } from 'helpers/firestore'; 
 
-const ETIDataBanks = ({ idEvent, event, dataBanks }) => {
+const ETIDataBanks = ({ idEvent, event, dataBanks, isEditingRows }) => {
   const [rows, setRows] = useState([]);
   const [editRowsModel, setEditRowsModel] = useState({});
   const [anchorEl, setAnchorEl] = useState(null);
@@ -79,6 +79,7 @@ const ETIDataBanks = ({ idEvent, event, dataBanks }) => {
 
   const handleEditClick = () => {
     setIsEditing(true);
+    isEditingRows(isEditing);
     handleMenuClose();
   };
 
@@ -91,6 +92,7 @@ const ETIDataBanks = ({ idEvent, event, dataBanks }) => {
       await createOrUpdateDoc('', row, row.id);
     }
     setIsEditing(false);
+    isEditingRows(isEditing);
   };
 
   const columns = [
@@ -113,7 +115,7 @@ const ETIDataBanks = ({ idEvent, event, dataBanks }) => {
               style={{ background: 'transparent', boxShadow: 'none', border: 'none', margin: 0 }}
               onClick={handleConfirmClick}
             >
-              <img src={'/img/icon/btnConfirm.png'} alt="btnConfirm" style={{ width: '100%', height: 'auto' }} />
+              <img src={'/img/icon/btnConfirm.svg'} alt="btnConfirm" style={{ width: '100%', height: 'auto' }} />
             </Button>
           )}
           

--- a/src/components/ETIMercadoPago.jsx
+++ b/src/components/ETIMercadoPago.jsx
@@ -6,7 +6,7 @@ import { Box, Button, Grid, Typography, Menu, MenuItem, } from '@mui/material';
 import { DataGrid } from '@mui/x-data-grid';
 import { createOrUpdateDoc } from 'helpers/firestore'; 
 
-const ETIMercadoPago = ( { idEvent, event, dataMP }) => {
+const ETIMercadoPago = ( { idEvent, event, dataMP, isEditingRows }) => {
   const [rows, setRows] = useState([]);
   const [editRowsModel, setEditRowsModel] = useState({});
   const [anchorEl, setAnchorEl] = useState(null);
@@ -79,6 +79,7 @@ const ETIMercadoPago = ( { idEvent, event, dataMP }) => {
 
   const handleEditClick = () => {
     setIsEditing(true);
+    isEditingRows(isEditing);
     handleMenuClose();
   };
 
@@ -91,6 +92,7 @@ const ETIMercadoPago = ( { idEvent, event, dataMP }) => {
       await createOrUpdateDoc('', row, row.id);
     }
     setIsEditing(false);
+    isEditingRows(isEditing);
   };
 
   const columns = [
@@ -110,7 +112,7 @@ const ETIMercadoPago = ( { idEvent, event, dataMP }) => {
               style={{ background: 'transparent', boxShadow: 'none', border: 'none', margin: 0 }}
               onClick={handleConfirmClick}
             >
-              <img src={'/img/icon/btnConfirm.svg'} alt="btnDelete" style={{ width: '100%', height: 'auto' }} />
+              <img src={'/img/icon/btnConfirm.svg'} alt="btnConfirm" style={{ width: '100%', height: 'auto' }} />
             </Button>
           )}
           

--- a/src/modules/superAdmin/events/NewEditEvent.tsx
+++ b/src/modules/superAdmin/events/NewEditEvent.tsx
@@ -16,6 +16,7 @@ import ETIEventDate from 'components/ETIEventDates';
 export default function NewEditEvent({ selectedEvent, setChangeEvent2, changeEvent2 }: { selectedEvent: EtiEvent | null, setChangeEvent2 : Function, changeEvent2 : boolean }) {
 
   const alertText: string = 'Este campo no puede estar vacío';
+  const alerText2: string = 'Tienes cambios que no seran guardados.'
   const EventFormSchema = object({
     dateEnd: date().required(alertText),
     dateSignupOpen: date().required(alertText),
@@ -40,6 +41,10 @@ export default function NewEditEvent({ selectedEvent, setChangeEvent2, changeEve
   const [alojamientoData, setAlojamientoData] = useState([null]);
   const [dataBanks, setDataBanks] = useState([null])
   const [dataMP, setDataMP] = useState([null])
+  const [isEditingAlojamiento, setIsEditingAlojamiento] = useState(true);
+  const [isEditingDataBanks, setIsEditingDataBanks] = useState(true);
+  const [isEditingDataMP, setIsEditingDataMP] = useState(true);
+  
 
   const updateAlojamientoData = (newData) => {
     setAlojamientoData(newData);
@@ -64,20 +69,25 @@ export default function NewEditEvent({ selectedEvent, setChangeEvent2, changeEve
   const handleCreateEvent = async (values: any) => {
     try {
       if(!changeEvent2){
-      if (alojamientoData && alojamientoData.length > 0) {
-        values.alojamiento = alojamientoData;
-      }
-  
-      if (dataBanks && dataBanks.length > 0) {
-        values.datosBancarios = dataBanks;
-      }
-  
-      if (dataMP && dataMP.length > 0) {
-        values.linkMercadoPago = dataMP;  
-      }
-      await createOrUpdateDoc('events', values, idEvent === 'new' ? undefined : idEvent);
+        if (alojamientoData && alojamientoData.length > 0) {
+          values.alojamiento = alojamientoData;
+        }
+    
+        if (dataBanks && dataBanks.length > 0) {
+          values.datosBancarios = dataBanks;
+        }
+    
+        if (dataMP && dataMP.length > 0) {
+          values.linkMercadoPago = dataMP;  
+        }
+
+        if(!isEditingAlojamiento || !isEditingDataBanks || !isEditingDataMP){
+          alert(alerText2)
+          return;
+        }
+        await createOrUpdateDoc('events', values, idEvent === 'new' ? undefined : idEvent);
       } else {
-        alert('Tienes cambios que no seran guardados.')
+        alert(alerText2)
       }
     } catch (error) {
       console.error(error);
@@ -150,15 +160,15 @@ export default function NewEditEvent({ selectedEvent, setChangeEvent2, changeEve
                           
 
                           <Grid item md={12} sm={12} xs={12}>
-                            <ETIAlojamiento idEvent={idEvent} event={selectedEvent} updateAlojamientoData={updateAlojamientoData} />
+                            <ETIAlojamiento idEvent={idEvent} event={selectedEvent} updateAlojamientoData={updateAlojamientoData} isEditingRows={setIsEditingAlojamiento}/>
                           </Grid>
 
                           <Grid item md={12} sm={12} xs={12}>
-                            <ETIDataBanks idEvent={idEvent} event={selectedEvent} dataBanks={updateDataBanks}/>
+                            <ETIDataBanks idEvent={idEvent} event={selectedEvent} dataBanks={updateDataBanks} isEditingRows={setIsEditingDataBanks}/> 
                           </Grid> 
 
                           <Grid item md={12} sm={12} xs={12}>
-                            <ETIMercadoPago idEvent={idEvent} event={selectedEvent} dataMP={updateDataMP}/>
+                            <ETIMercadoPago idEvent={idEvent} event={selectedEvent} dataMP={updateDataMP} isEditingRows={setIsEditingDataMP}/> 
                           </Grid>
 
                           <Grid item md={12} sm={12} xs={12}>


### PR DESCRIPTION
 ## *Brief Summary*

message alert added if rows of datagrid is editing and user press save

## *Type of change:*


- [x]  *Feature*
- [ ]  *Bugfix*
- [x]  *Refactor*
- [ ]  *Hotfix*
- [ ]  *Breaking change ()*
- [ ]  *Documentation*

## *Additional dependencies*

none

## *Screenshots*

![image](https://github.com/mecantronic/etitango-front/assets/111368791/250a4dd7-8e1c-4c76-8912-d0c3998f2591)


